### PR TITLE
Add test coverage for multiple apps

### DIFF
--- a/bag/tests.py
+++ b/bag/tests.py
@@ -1,1 +1,45 @@
-# Create your tests here.
+from django.test import TestCase
+from django.urls import reverse
+
+from products.models import Product, Category
+
+
+class BagViewsTests(TestCase):
+    def setUp(self):
+        category = Category.objects.create(name="snack")
+        self.product = Product.objects.create(name="Chips", description="crispy", price=1, category=category)
+
+    def test_add_adjust_and_remove_bag(self):
+        add_url = reverse("add_to_bag", args=[self.product.id])
+        adjust_url = reverse("adjust_bag", args=[self.product.id])
+        remove_url = reverse("remove_from_bag", args=[self.product.id])
+
+        # add
+        response = self.client.post(add_url, {"quantity": 2, "redirect_url": reverse("products")})
+        self.assertEqual(self.client.session["bag"].get(str(self.product.id)), 2)
+        self.assertEqual(response.status_code, 302)
+
+        # adjust
+        response = self.client.post(adjust_url, {"quantity": 1})
+        self.assertEqual(self.client.session["bag"].get(str(self.product.id)), 1)
+        self.assertEqual(response.status_code, 302)
+
+        # remove
+        response = self.client.post(remove_url)
+        self.assertNotIn(str(self.product.id), self.client.session.get("bag", {}))
+        self.assertEqual(response.status_code, 200)
+
+    def test_view_bag_template(self):
+        url = reverse("view_bag")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "bag/bag.html")
+
+    def test_bag_contents_context(self):
+        add_url = reverse("add_to_bag", args=[self.product.id])
+        self.client.post(add_url, {"quantity": 3, "redirect_url": reverse("products")})
+        from bag.contexts import bag_contents
+        request = self.client.get(reverse("view_bag")).wsgi_request
+        context = bag_contents(request)
+        self.assertEqual(context["product_count"], 3)
+        self.assertTrue(context["bag_items"])

--- a/blog/tests.py
+++ b/blog/tests.py
@@ -1,1 +1,34 @@
-# Create your tests here.
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth.models import User
+
+from .models import Post, Comment
+
+
+class BlogModelTests(TestCase):
+    def test_post_and_comment_str(self):
+        user = User.objects.create(username="author")
+        post = Post.objects.create(title="Title", author=user, body="Body", status=Post.Status.PUBLISHED)
+        comment = Comment.objects.create(author="Anon", body="hi", post=post)
+        self.assertEqual(str(post), "Title")
+        self.assertIn("Anon", str(comment))
+
+
+class BlogViewsTests(TestCase):
+    def setUp(self):
+        user = User.objects.create(username="author")
+        self.post = Post.objects.create(title="A", author=user, body="b", status=Post.Status.PUBLISHED)
+
+    def test_post_list_view(self):
+        url = reverse("blog:post_list")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "blog/post_list.html")
+        self.assertIn(self.post, response.context["posts"])
+
+    def test_post_detail_view(self):
+        url = reverse("blog:post_detail", args=[self.post.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "blog/post_detail.html")
+        self.assertEqual(response.context["object"], self.post)

--- a/checkout/tests.py
+++ b/checkout/tests.py
@@ -1,1 +1,37 @@
-# Create your tests here.
+from django.test import TestCase
+
+from products.models import Product, Category
+from .models import Order, OrderLineItem
+
+
+class OrderModelTests(TestCase):
+    def setUp(self):
+        category = Category.objects.create(name="drink")
+        self.product = Product.objects.create(name="Water", description="clear", price=1, category=category)
+
+    def test_order_number_generated(self):
+        order = Order.objects.create(
+            full_name="Tester",
+            email="test@example.com",
+            phone_number="1234",
+            country="US",
+            town_or_city="Town",
+            street_address1="Street",
+        )
+        self.assertTrue(order.order_number)
+        self.assertEqual(len(order.order_number), 32)
+
+    def test_order_lineitem_updates_total(self):
+        order = Order.objects.create(
+            full_name="Tester",
+            email="t@example.com",
+            phone_number="1234",
+            country="US",
+            town_or_city="Town",
+            street_address1="Street",
+        )
+        OrderLineItem.objects.create(order=order, product=self.product, quantity=2)
+        order.refresh_from_db()
+        expected_total = self.product.price * 2
+        self.assertEqual(order.order_total, expected_total)
+        self.assertEqual(order.grand_total, expected_total if expected_total >= 50 else expected_total + order.delivery_cost)

--- a/home/tests.py
+++ b/home/tests.py
@@ -1,1 +1,9 @@
-# Create your tests here.
+from django.test import TestCase
+from django.urls import reverse
+
+
+class HomeViewTests(TestCase):
+    def test_index_view(self):
+        response = self.client.get(reverse('home'))
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'home/index.html')

--- a/products/tests.py
+++ b/products/tests.py
@@ -1,1 +1,52 @@
-# Create your tests here.
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth.models import User
+
+from .models import Product, Category, Allergen, Review
+
+
+class ProductModelTests(TestCase):
+    def test_category_str_and_friendly_name(self):
+        category = Category.objects.create(name="meat", friendly_name="Meat")
+        self.assertEqual(str(category), "meat")
+        self.assertEqual(category.get_friendly_name(), "Meat")
+
+    def test_product_and_allergen_str(self):
+        category = Category.objects.create(name="fish")
+        allergen = Allergen.objects.create(name="nuts")
+        product = Product.objects.create(
+            category=category,
+            name="Tuna",
+            description="Fresh tuna",
+            price=10,
+        )
+        product.allergens.add(allergen)
+        self.assertEqual(str(allergen), "nuts")
+        self.assertEqual(str(product), "Tuna")
+
+    def test_review_str(self):
+        user = User.objects.create_user(username="tester")
+        product = Product.objects.create(name="Yam", description="desc", price=5)
+        review = Review.objects.create(product=product, user=user, text="Ok", rating=3)
+        self.assertIn(user.username, str(review))
+        self.assertIn(product.name, str(review))
+
+
+class ProductViewsTests(TestCase):
+    def setUp(self):
+        self.category = Category.objects.create(name="veg")
+        self.product = Product.objects.create(name="Carrot", description="desc", price=2, category=self.category)
+
+    def test_all_products_view(self):
+        url = reverse("products")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "products/products.html")
+        self.assertIn(self.product, response.context["products"])
+
+    def test_product_detail_view(self):
+        url = reverse("product_detail", args=[self.product.id])
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "products/product_detail.html")
+        self.assertEqual(response.context["product"], self.product)

--- a/profiles/tests.py
+++ b/profiles/tests.py
@@ -1,1 +1,12 @@
-# Create your tests here.
+from django.test import TestCase
+from django.contrib.auth.models import User
+
+from .models import UserProfile
+
+
+class ProfileModelTests(TestCase):
+    def test_profile_created_on_user_creation(self):
+        user = User.objects.create_user(username="tester")
+        self.assertTrue(UserProfile.objects.filter(user=user).exists())
+        profile = UserProfile.objects.get(user=user)
+        self.assertEqual(str(profile), "tester")


### PR DESCRIPTION
## Summary
- implement model and view tests for products app
- add bag view and context tests
- test checkout order and line items
- add basic blog view and model tests
- ensure user profiles created via signal
- test home index view

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684183b150a883239c8652dadb063c95