### PR TITLE
Fix reverse import in products views

### DIFF
--- a/products/views.py
+++ b/products/views.py
@@ -2,12 +2,12 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.db.models import Q
 from django.db.models.functions import Lower
-from django.shortcuts import render, redirect, reverse, get_object_or_404
+from django.shortcuts import render, redirect, get_object_or_404
 
 from .forms import ProductForm
 from .models import Product, Category, Review
 
-from django.urls import reverse_lazy
+from django.urls import reverse, reverse_lazy
 from django.views.generic import DeleteView
 
 


### PR DESCRIPTION
## Summary
- import `reverse` from `django.urls` instead of `django.shortcuts`
- cleanup `products.views`

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6841826b8f988323b6564aa27b270c01